### PR TITLE
Finalizing price range filter

### DIFF
--- a/assets/component-filters-price-range.js
+++ b/assets/component-filters-price-range.js
@@ -38,8 +38,8 @@ class PriceRange extends HTMLElement {
   }
 
   updateUI(min, max) {
-    this.minPriceText.textContent = `${this.currencySymbol}${min}`;
-    this.maxPriceText.textContent = `${this.currencySymbol}${max}`;
+    this.minPriceText.textContent = `${this.currencySymbol}${min}.00`;
+    this.maxPriceText.textContent = `${this.currencySymbol}${max}.00`;
     this.rangeSlider.style.left = `${(min / this.rangeInputs[0].max) * 100}%`;
     this.rangeSlider.style.right = `${100 - (max / this.rangeInputs[1].max) * 100}%`;
     this.rangeInputs[0].value = min;

--- a/sections/main-collection.liquid
+++ b/sections/main-collection.liquid
@@ -47,7 +47,6 @@
 {{ 'component-pagination.css' | asset_url | stylesheet_tag }}
 {{ 'section-main-collection.css' | asset_url | stylesheet_tag }}
 
-
 <div class="color-{{ section.settings.color_scheme }} page-width">
   <div class="collection-hero color-{{ section.settings.color_scheme }}">
     <div class="collection-hero__text-wrapper">
@@ -144,30 +143,27 @@
                   {% liquid
                     assign has_active_filters = false
                     for f in collection.filters
-                      if f.active_values.size > 0
-                        assign has_active_filters = true
+                      if f.type == 'price_range'
+                        if f.min_value.value > 0 or f.max_value.value < f.range_max
+                          assign has_active_filters = true
+                        endif
+                      else
+                        if f.active_values.size > 0
+                          assign has_active_filters = true
+                        endif
                       endif
                     endfor
                   %}
 
                   {%- for f in collection.filters -%}
-                    {% for v in f.active_values %}
-                      <div class="filter active-filter-item">
-                        <span>{{ f.label | escape }}: {{ v.label | escape -}}</span>
-                        <div
-                          class="filter-close"
-                          data-render-section-url="{{ v.url_to_remove }}"
-                        >
-                          {{- 'icon-close.svg' | inline_asset_content -}}
-                        </div>
-                      </div>
-                    {% endfor %}
-                    {% if f.type == 'price_range' and f.min_value.value or f.max_value.value %}
+                    {% if f.type == 'price_range' and f.min_value.value > 0 or f.max_value.value < f.range_max %}
                       {% assign min = f.min_value.value %}
                       {% assign max = f.max_value.value %}
-                      
                       <div class="filter active-filter-item">
-                        <span>{{ f.label | escape }}: {{ min | money -}} - {{ max | money -}}</span>
+                        <span>
+                          {{- f.label | escape }}: {{ min | money -}}
+                          - {{ max | money -}}
+                        </span>
                         <div
                           class="filter-close"
                           data-render-section-url="{{ f.url_to_remove }}"
@@ -175,6 +171,18 @@
                           {{- 'icon-close.svg' | inline_asset_content -}}
                         </div>
                       </div>
+                    {% else %}
+                      {% for v in f.active_values %}
+                        <div class="filter active-filter-item">
+                          <span>{{ f.label | escape }}: {{ v.label | escape -}}</span>
+                          <div
+                            class="filter-close"
+                            data-render-section-url="{{ v.url_to_remove }}"
+                          >
+                            {{- 'icon-close.svg' | inline_asset_content -}}
+                          </div>
+                        </div>
+                      {% endfor %}
                     {% endif %}
                   {%- endfor -%}
 
@@ -218,7 +226,6 @@
 <script src="{{ 'component-collection-info.js' | asset_url }}" defer="defer"></script>
 <script src="{{ 'component-product-card.js' | asset_url }}" defer="defer"></script>
 <script src="{{ 'component-filters-price-range.js' | asset_url }}" defer="defer"></script>
-
 
 {% schema %}
 {

--- a/sections/main-collection.liquid
+++ b/sections/main-collection.liquid
@@ -162,6 +162,20 @@
                         </div>
                       </div>
                     {% endfor %}
+                    {% if f.type == 'price_range' and f.min_value.value or f.max_value.value %}
+                      {% assign min = f.min_value.value %}
+                      {% assign max = f.max_value.value %}
+                      
+                      <div class="filter active-filter-item">
+                        <span>{{ f.label | escape }}: {{ min | money -}} - {{ max | money -}}</span>
+                        <div
+                          class="filter-close"
+                          data-render-section-url="{{ f.url_to_remove }}"
+                        >
+                          {{- 'icon-close.svg' | inline_asset_content -}}
+                        </div>
+                      </div>
+                    {% endif %}
                   {%- endfor -%}
 
                   {% if has_active_filters %}

--- a/snippets/component-filters-price-range.liquid
+++ b/snippets/component-filters-price-range.liquid
@@ -140,13 +140,13 @@
           type="range"
           class="min-range"
           min="0"
-          max="{{ filter.range_max | money_without_currency }}"
+          max="{{ filter.range_max | divided_by: 100 }}"
           {%- if filter.min_value.value -%}
-            value="{{ filter.min_value.value | money_without_currency }}"
+            value="{{ filter.min_value.value | divided_by: 100 }}"
           {%- else -%}
             value="0"
           {%- endif -%}
-          step="1"
+          step="any"
           name="{{ filter.min_value.param_name }}"
           data-render-section
         >
@@ -154,13 +154,13 @@
           type="range"
           class="max-range"
           min="0"
-          max="{{ filter.range_max | money_without_currency  }}"
+          max="{{ filter.range_max | divided_by: 100 }}"
           {%- if filter.max_value.value -%}
-            value="{{ filter.max_value.value | money_without_currency }}"
+            value="{{ filter.max_value.value | divided_by: 100 }}"
           {%- else -%}
-            value="{{ filter.range_max | money_without_currency }}"
+            value="{{ filter.range_max | divided_by: 100 }}"
           {%- endif -%}
-          step="1"
+          step="any"
           name="{{ filter.max_value.param_name }}"
           data-render-section
         >


### PR DESCRIPTION
This pull request includes several changes to improve the handling of price ranges and active filters in the main collection section. The most important changes include updating the price range display, modifying the filter logic for price ranges, and adjusting the maximum range values and steps for price inputs.

Changes to price range display:

* [`assets/component-filters-price-range.js`](diffhunk://#diff-2fcb3d4b7496cd4f92deced33d146e183db7133943f5ae8062200c1ca5e0755aL41-R42): Updated the `updateUI` method to display prices with two decimal places.

Changes to filter logic:

* [`sections/main-collection.liquid`](diffhunk://#diff-59ecc6629c42481e325240c369c3fef409a32a69cc374b8a00453ffe0abda497R146-R174): Modified the logic to identify active filters for price ranges and display them accordingly. [[1]](diffhunk://#diff-59ecc6629c42481e325240c369c3fef409a32a69cc374b8a00453ffe0abda497R146-R174) [[2]](diffhunk://#diff-59ecc6629c42481e325240c369c3fef409a32a69cc374b8a00453ffe0abda497R186)

Adjustments to price input ranges:

* [`snippets/component-filters-price-range.liquid`](diffhunk://#diff-b777598adcef6a6a8208c589f4da6880b96521e84859db73e82c0ff7d64a2fa1L143-R163): Changed the maximum range values and steps for price inputs to handle values divided by 100 and use `step="any"` for more precise adjustments.

Minor cleanup:

* [`sections/main-collection.liquid`](diffhunk://#diff-59ecc6629c42481e325240c369c3fef409a32a69cc374b8a00453ffe0abda497L50): Removed unnecessary blank lines for better code readability. [[1]](diffhunk://#diff-59ecc6629c42481e325240c369c3fef409a32a69cc374b8a00453ffe0abda497L50) [[2]](diffhunk://#diff-59ecc6629c42481e325240c369c3fef409a32a69cc374b8a00453ffe0abda497L208)