### PR TITLE
Add product carousel section

### DIFF
--- a/assets/component-product-carousel.js
+++ b/assets/component-product-carousel.js
@@ -1,0 +1,38 @@
+class ProductCarousel extends HTMLElement {
+  connectedCallback() {
+    if (typeof Swiper !== 'undefined') {
+      this.initSwiper();
+    } else {
+      const script = document.getElementById('swiper-script');
+      if (script) {
+        script.addEventListener('load', this.initSwiper.bind(this));
+      }
+    }
+  }
+
+  initSwiper() {
+    const element = this.querySelector('.swiper');
+    if (!element) return;
+    this.swiper = new Swiper(element, {
+      slidesPerView: 1,
+      spaceBetween: 16,
+      loop: true,
+      pagination: {
+        el: this.querySelector('.swiper-pagination'),
+        clickable: true,
+      },
+      navigation: {
+        nextEl: this.querySelector('.swiper-button-next'),
+        prevEl: this.querySelector('.swiper-button-prev'),
+      },
+      breakpoints: {
+        750: { slidesPerView: 2 },
+        990: { slidesPerView: 4 },
+      },
+    });
+  }
+}
+
+if (!customElements.get('product-carousel')) {
+  customElements.define('product-carousel', ProductCarousel);
+}

--- a/assets/section-product-carousel.css
+++ b/assets/section-product-carousel.css
@@ -1,0 +1,16 @@
+.product-carousel-section {
+  position: relative;
+}
+
+.product-carousel-section .swiper {
+  padding-bottom: 2rem;
+}
+
+.product-carousel-section .swiper-button-next,
+.product-carousel-section .swiper-button-prev {
+  color: black;
+}
+
+.product-carousel-section .swiper-pagination-bullet-active {
+  background: black;
+}

--- a/sections/product-carousel.liquid
+++ b/sections/product-carousel.liquid
@@ -1,0 +1,63 @@
+{% comment %} /sections/product-carousel.liquid {% endcomment %}
+
+{{ 'swiper7.4.1.min.css' | asset_url | stylesheet_tag }}
+{{ 'component-product-card.css' | asset_url | stylesheet_tag }}
+{{ 'component-product-price.css' | asset_url | stylesheet_tag }}
+{{ 'section-product-carousel.css' | asset_url | stylesheet_tag }}
+
+{%- if section.blocks.size > 0 -%}
+  <product-carousel class="product-carousel-section page-width">
+    <div class="swiper">
+      <div class="swiper-wrapper">
+        {%- for block in section.blocks -%}
+          {%- assign product = block.settings.product -%}
+          <div class="swiper-slide" {{ block.shopify_attributes }}>
+            {% render 'component-product-card',
+              card_product: product,
+              show_vendor: false,
+              enable_swatches: false %}
+          </div>
+        {%- endfor -%}
+      </div>
+      <div class="swiper-button-prev"></div>
+      <div class="swiper-button-next"></div>
+      <div class="swiper-pagination"></div>
+    </div>
+  </product-carousel>
+
+  <script src="{{ 'swiper7.4.1.min.js' | asset_url }}" defer="defer" id="swiper-script"></script>
+  <script src="{{ 'component-product-carousel.js' | asset_url }}" defer="defer"></script>
+{%- endif -%}
+
+{% schema %}
+{
+  "name": "Product Carousel",
+  "tag": "section",
+  "class": "product-carousel",
+  "blocks": [
+    {
+      "type": "product_card",
+      "name": "Product Card",
+      "limit": 10,
+      "settings": [
+        {
+          "type": "product",
+          "id": "product",
+          "label": "Product"
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "name": "Product Carousel",
+      "blocks": [
+        { "type": "product_card" },
+        { "type": "product_card" },
+        { "type": "product_card" },
+        { "type": "product_card" }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/templates/index.json
+++ b/templates/index.json
@@ -528,6 +528,42 @@
         "padding_top": 36,
         "padding_bottom": 36
       }
+    },
+    "product_carousel_1": {
+      "type": "product-carousel",
+      "blocks": {
+        "block_1": {
+          "type": "product_card",
+          "settings": {
+            "product": "alex-twill-pant-navy"
+          }
+        },
+        "block_2": {
+          "type": "product_card",
+          "settings": {
+            "product": "alia-knit-trouser-1"
+          }
+        },
+        "block_3": {
+          "type": "product_card",
+          "settings": {
+            "product": "alverstone-jacket-midnight"
+          }
+        },
+        "block_4": {
+          "type": "product_card",
+          "settings": {
+            "product": "3-4-sleeve-kimono-dress-coral"
+          }
+        }
+      },
+      "block_order": [
+        "block_1",
+        "block_2",
+        "block_3",
+        "block_4"
+      ],
+      "settings": {}
     }
   },
   "order": [
@@ -541,6 +577,7 @@
     "testimonials_1",
     "product_comparison_1",
     "celebrities_endorsement_1",
-    "image_with_text_kj8i3w"
+    "image_with_text_kj8i3w",
+    "product_carousel_1"
   ]
 }


### PR DESCRIPTION
## Summary
- create `product-carousel` section with Swiper-based slider
- add custom element to initialize the carousel without using Shadow DOM
- style the new section
- include the section on the homepage

## Testing
- `npm test` *(fails: Error: no test specified)*